### PR TITLE
Update android gradle plugin version and support dex-in-process

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.0-rc1'
+        classpath 'com.android.tools.build:gradle:2.2.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$KOTLIN_VERSION"
         classpath "com.novoda:bintray-release:0.3.4"
         classpath 'com.neenbedankt.gradle.plugins:android-apt:1.8'

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,3 +9,6 @@ VERSION=0.8.0
 DESCRIPTION=Reactive SharedPreferences code generator for Android.
 WEBSITE=https://github.com/hotchemi/tiamat
 LICENCES=['Apache-2.0']
+
+# Gradle configuration
+org.gradle.jvmargs=-Xmx1536M

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.1-all.zip


### PR DESCRIPTION
Thank you for awesome library. 👍 
(I think that this library is good solution of twitter like-button problem!)

I edited a bit.

* Use stable version of Android Gradle Plugin.
* Use Gradle 3.1
* Use dex-in-process by add jvmargs

I checked this sample app and unit tests.