### PR TITLE
Support rxjava2

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,10 +66,10 @@ You can use `asObservable()` method to get a RxJava Observable.
 Observable<Boolean> value = preferences.getBooleanValue().asObservable();
 ```
 
-You can also use `asAction()` method to get an Action that update value.
+You can also use `asConsumer()` method to get an Action that update value.
 
 ```java
-Action1<? super Boolean> value = preferences.getBooleanValue().asAction();
+Consumer<? super Boolean> value = preferences.getBooleanValue().asConsumer();
 ```
 
 It means you can monitor the change of Preferences automatically and compound actions with other Rx library.

--- a/README.md
+++ b/README.md
@@ -60,7 +60,13 @@ preferences.removeStringValue();
 boolean value = preferences.getBooleanValue().asValue();
 ```
 
-You can use `asObservable()` method to get a RxJava Observable.
+You can use `asFlowable()` method to get a RxJava Flowable.
+
+```java
+Flowable<Boolean> value = preferences.getBooleanValue().asFlowable();
+```
+
+Alternatively, `asObservable()` method is available as a choice of switch over.
 
 ```java
 Observable<Boolean> value = preferences.getBooleanValue().asObservable();

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -13,11 +13,12 @@ android {
     }
     sourceCompatibility = JavaVersion.VERSION_1_7
     targetCompatibility = JavaVersion.VERSION_1_7
+
 }
 
 dependencies {
     compile project(":annotations")
-    compile 'io.reactivex:rxjava:1.2.0'
+    compile 'io.reactivex.rxjava2:rxjava:2.0.2'
     testCompile 'junit:junit:4.12'
     testCompile 'org.robolectric:robolectric:3.1'
     testCompile 'org.assertj:assertj-core:1.7.0'

--- a/library/src/main/java/tiamat/Preference.java
+++ b/library/src/main/java/tiamat/Preference.java
@@ -2,6 +2,7 @@ package tiamat;
 
 import android.content.SharedPreferences;
 
+import io.reactivex.Flowable;
 import io.reactivex.Observable;
 import io.reactivex.functions.Consumer;
 import io.reactivex.functions.Function;
@@ -14,9 +15,9 @@ public class Preference<T> {
     private final String key;
     private final T defValue;
     private final Proxy<T> proxy;
-    private final Observable<T> values;
+    private final Flowable<T> values;
 
-    Preference(SharedPreferences preferences, final String key, T defValue, Proxy<T> proxy, final Observable<String> keyChanges) {
+    Preference(SharedPreferences preferences, final String key, T defValue, Proxy<T> proxy, final Flowable<String> keyChanges) {
         this.preferences = preferences;
         this.key = key;
         this.defValue = defValue;
@@ -41,8 +42,12 @@ public class Preference<T> {
         return proxy.get(key, defValue, preferences);
     }
 
-    public Observable<T> asObservable() {
+    public Flowable<T> asFlowable() {
         return values;
+    }
+
+    public Observable<T> asObservable() {
+        return values.toObservable();
     }
 
     public Consumer<? super T> asConsumer(){

--- a/library/src/test/java/tiamat/PreferenceTest.java
+++ b/library/src/test/java/tiamat/PreferenceTest.java
@@ -12,6 +12,7 @@ import org.robolectric.RuntimeEnvironment;
 
 import io.reactivex.functions.Consumer;
 import io.reactivex.observers.TestObserver;
+import io.reactivex.subscribers.TestSubscriber;
 
 import static android.preference.PreferenceManager.getDefaultSharedPreferences;
 import static java.util.Collections.singleton;
@@ -182,6 +183,28 @@ public class PreferenceTest {
         o4.assertValues("foo");
     }
 
+    @Test
+    public void asFlowable() {
+        Preference<String> preference = rxPreferences.getString("key1", "defValue");
+
+        // Flowable can be tested with TestSubscriber
+        // https://github.com/ReactiveX/RxJava/wiki/What's-different-in-2.0#testing
+        TestSubscriber<String> s1 = preference.asFlowable().test();
+        s1.assertValue("defValue");
+
+        rxPreferences.putString("key1", "value1");
+        TestSubscriber<String> s2 = preference.asFlowable().test();
+        s2.assertValues("value1");
+
+        rxPreferences.remove("key1");
+        TestSubscriber<String> s3 = preference.asFlowable().test();
+        s3.assertValues("defValue");
+
+        rxPreferences.putString("key1", "foo");
+        TestSubscriber<String> s4 = preference.asFlowable().test();
+        s4.assertValues("foo");
+
+    }
 
     @Test
     public void asConsumer() throws Exception {

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -29,6 +29,10 @@ android {
     lintOptions {
         abortOnError false
     }
+
+    packagingOptions {
+        exclude 'META-INF/rxjava.properties'
+    }
 }
 
 dependencies {
@@ -37,8 +41,9 @@ dependencies {
     provided project(":compiler")
     compile 'com.google.dagger:dagger:2.6'
     provided 'com.google.dagger:dagger-compiler:2.6'
-    compile 'io.reactivex:rxandroid:1.2.1'
+    compile 'io.reactivex.rxjava2:rxandroid:2.0.1'
     compile 'com.jakewharton.rxbinding:rxbinding:0.4.0'
+    compile 'com.github.akarnokd:rxjava2-interop:0.6.1'
     testCompile 'junit:junit:4.12'
     androidTestCompile('com.android.support.test.espresso:espresso-core:2.2.2', {
         exclude group: 'com.android.support', module: 'support-annotations'

--- a/sample/src/main/java/tiamat/sample/BaseActivity.java
+++ b/sample/src/main/java/tiamat/sample/BaseActivity.java
@@ -28,7 +28,7 @@ abstract class BaseActivity extends AppCompatActivity {
     }
 
     void bindPreference(CheckBox checkBox, Preference<Boolean> preference) {
-        compositeDisposable.add(preference.asObservable()
+        compositeDisposable.add(preference.asFlowable()
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(checkBox::setChecked));
         compositeDisposable.add(RxJavaInterop.toV2Observable(RxCompoundButton.checkedChanges(checkBox))

--- a/sample/src/main/java/tiamat/sample/NextActivity.java
+++ b/sample/src/main/java/tiamat/sample/NextActivity.java
@@ -7,6 +7,7 @@ import android.os.Bundle;
 
 import javax.inject.Inject;
 
+import io.reactivex.functions.Consumer;
 import tiamat.sample.databinding.ActivityNextBinding;
 
 public class NextActivity extends BaseActivity {
@@ -25,5 +26,6 @@ public class NextActivity extends BaseActivity {
         binding.nextButton.setOnClickListener(view -> finish());
         getComponent().inject(this);
         bindPreference(binding.nextCheckbox, sharedPreferences.getChecked());
+        Consumer<? super Boolean> value = sharedPreferences.getBooleanValue().asConsumer();
     }
 }

--- a/sample/src/main/java/tiamat/sample/NextActivity.java
+++ b/sample/src/main/java/tiamat/sample/NextActivity.java
@@ -7,7 +7,6 @@ import android.os.Bundle;
 
 import javax.inject.Inject;
 
-import io.reactivex.functions.Consumer;
 import tiamat.sample.databinding.ActivityNextBinding;
 
 public class NextActivity extends BaseActivity {
@@ -26,6 +25,5 @@ public class NextActivity extends BaseActivity {
         binding.nextButton.setOnClickListener(view -> finish());
         getComponent().inject(this);
         bindPreference(binding.nextCheckbox, sharedPreferences.getChecked());
-        Consumer<? super Boolean> value = sharedPreferences.getBooleanValue().asConsumer();
     }
 }


### PR DESCRIPTION
Here I made a PR to support RxJava2
Basically RxJava2.x backports RxJava1.x by using `import rx.Observable.*`), but not sure if Tiamat should support RxJava1 since it would cause a heavy lifting of supporting old versions. What's your opinion? 